### PR TITLE
Updated to nix version 2.3.10 to get latest packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN yum install -y -q wget openssl \
   && echo hosts: dns files > /etc/nsswitch.conf
 
 # Download Nix and install it into the system.
-RUN wget -q https://nixos.org/releases/nix/nix-2.3/nix-2.3-x86_64-linux.tar.xz \
-  && tar xf nix-2.3-x86_64-linux.tar.xz \
+RUN wget -q https://nixos.org/releases/nix/nix-2.3.10/nix-2.3.10-x86_64-linux.tar.xz \
+  && tar xf nix-2.3.10-x86_64-linux.tar.xz \
   && groupadd -g 30000 nixbld \
   && for i in $(seq 1 30); do adduser -r -d /var/empty -u $((30000 + i)) -g nixbld nixbld$i ; done \
   && mkdir -m 0755 /etc/nix \


### PR DESCRIPTION
I created a new base image with the latest version of the Nix package manager (2.3.10), and pushed it to DockerHub.  The image is `xsede/centos-nix-base:nix-2.3.10` on DockerHub (`nix-2.3.10` simply replaces the `latest` tag).  With this, you can get the packages available in the 20.09 release of NixOS, which is the default version in the search: https://search.nixos.org/packages.  I've made a new branch in the GitHub repo for the base image for this new version.

**To Do:**
We need to test that all other images using `xsede/centos-nix-base:latest` will work with this new version.  I've opened this pull request to merge this version to master so that we can track the testing progress.  Feel free to add a comment here for any containers you test with the new version.  Once we've tested all dependent containers, and they work, we can merge this request and update the `nix-2.3.10` to `latest`.  The old version will still be available at the nix-2.3 branch of the repo and the tag of the same name in DockerHub (which I also just created), once that is done.